### PR TITLE
Fix path.match return value test, from false to null.

### DIFF
--- a/lib/atom-phpcs.coffee
+++ b/lib/atom-phpcs.coffee
@@ -52,7 +52,7 @@ module.exports = AtomPHPCS =
         if typeof editor == 'object'
           path = editor.getPath()
           if typeof path != 'undefined'
-            if path.match('\.php$|\.inc$') isnt false
+            if path.match('\.php$|\.inc$') isnt null
               AtomPHPCS.generateErrors(editor)
     workspaceCb = (event) ->
       editor = event.TextEditor
@@ -101,7 +101,7 @@ module.exports = AtomPHPCS =
     if typeof editor == 'object'
       path = editor.getPath()
       if typeof path != 'undefined'
-        if path.match('\.php$|\.inc$') isnt false
+        if path.match('\.php$|\.inc$') isnt null
           @generateErrors(editor)
 
   codefixer: () ->
@@ -109,7 +109,7 @@ module.exports = AtomPHPCS =
     if typeof editor == 'object'
       path = editor.getPath()
       if typeof path != 'undefined'
-        if path.match('\.php$|\.inc$') isnt false
+        if path.match('\.php$|\.inc$') isnt null
           fixerCb = (message) ->
             AtomPHPCS.updateStatus(message)
             atom.workspace.open(path, [])


### PR DESCRIPTION
## Issue

On any open file, not ending in .php or .inc, for example README.md

The 1st line of the file will generate a Code Sniffer status bar message:

"No PHP was found in this file and short open tags are not allowed by this install of PHP. This file may be using short open tags but PHP does not allow them."

PHP Code Sniffer should only be called for matching files in the path.match('\.php$|\.inc$') test in lib/atom-phpcs.coffee lines 55, 104 and 112.

## Proposed solution

Change the path.match test to check that the result isn't null, instead of isn't false. 

[String.match](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/match)

**Return value** An Array containing the entire match result and any parentheses-captured matched results; _null if there were no matches_.