### PR TITLE
Addition of "noPatch" option, to prevent lack of diff/patch command

### DIFF
--- a/lib/atom-phpcs.coffee
+++ b/lib/atom-phpcs.coffee
@@ -28,6 +28,11 @@ module.exports = AtomPHPCS =
       description: "If selected, only show the errors"
       type: 'boolean'
       default: false
+    noPatch:
+      title: "'No patch' mode"
+      description: "If selected, do not use 'diff' command, especially for Windows systems"
+      type: 'boolean'
+      default: false
 
   editor: null
 
@@ -128,6 +133,8 @@ module.exports = AtomPHPCS =
     args = ["--standard="+standard, @filepath]
     if atom.config.get('atom-phpcs.errorsOnly') == true
       args.unshift("-n")
+    if atom.config.get('atom-phpcs.noPatch') == true
+      args.unshift("--no-patch")
 
     options = {cwd: directory}
 


### PR DESCRIPTION
On some Windows systems, diff/patch commands are not available, so it should be useful to be able to add "--no-patch" option